### PR TITLE
[Feature] strain list

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
   "singleQuote": false,
   "quoteProps": "as-needed",
   "bracketSpacing": true,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "tailwindConfig": "./tailwind.config.js"
 }

--- a/components/List.js
+++ b/components/List.js
@@ -1,0 +1,56 @@
+import { gql, useQuery, NetworkStatus } from "@apollo/client";
+import ListItem from "./ListItem";
+
+export const ALL_STRAINS_QUERY = gql`
+  query GetAllStrains($skip: Int!, $take: Int!) {
+    strains(skip: $skip, take: $take) {
+      id
+      name
+    }
+  }
+`;
+export const allStrainsQueryVars = {
+  skip: 0,
+  take: 10,
+};
+
+export default function List() {
+  const { loading, error, data, fetchMore, networkStatus } = useQuery(
+    ALL_STRAINS_QUERY,
+    {
+      variables: allStrainsQueryVars,
+      notifyOnNetworkStatusChange: true,
+    }
+  );
+  const loadingMoreStrains = networkStatus === NetworkStatus.fetchMore;
+
+  const loadMoreStrains = () => {
+    fetchMore({
+      variables: {
+        skip: strains.length,
+      },
+    });
+  };
+
+  if (error) return <h3>Error</h3>;
+  if (loading && !loadingMoreStrains) return <h3>Loading</h3>;
+
+  const { strains } = data;
+
+  return (
+    <div className={`flex h-auto w-screen flex-col gap-6`}>
+      {strains.map(listItem => (
+        <ListItem
+          key={listItem.id}
+          strainName={listItem.name}
+          topTerp={null}
+          thcLevel={null}
+          cbdLevel={null}
+        />
+      ))}
+      <button onClick={() => loadMoreStrains()} disabled={loadingMoreStrains}>
+        {loadingMoreStrains ? "Loading..." : "Show More"}
+      </button>
+    </div>
+  );
+}

--- a/components/ListItem.js
+++ b/components/ListItem.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+export default function ListItem(props) {
+  return (
+    <div
+      className={`flex h-24 w-full flex-col items-center justify-center gap-4 bg-gradient-to-b from-slate-50 to-gray-50`}
+    >
+      <h1 className={`text-center text-5xl font-bold`}>{props.strainName}</h1>
+      <ul className={`flex w-full items-center justify-around text-lg`}>
+        <li>{props.topTerp ? `${props.topTerp}` : `no data`}</li>
+        {props.thcLevel && <li>{props.thcLevel}%</li>}
+        {props.cbdLevel && <li>{props.cbdLevel}%</li>}
+      </ul>
+    </div>
+  );
+}

--- a/lib/apolloClient.js
+++ b/lib/apolloClient.js
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client";
+import { concatPagination } from "@apollo/client/utilities";
+import merge from "deepmerge";
+import isEqual from "lodash/isEqual";
+
+export const APOLLO_STATE_PROP_NAME = "__APOLLO_STATE__";
+
+let apolloClient;
+
+function createApolloClient() {
+  return new ApolloClient({
+    ssrMode: typeof window === "undefined",
+    link: new HttpLink({
+      uri: "https://nf-capstone-bubatz-dev.vercel.app/api/graphql", // Server URL (must be absolute)
+      credentials: "same-origin", // Additional fetch() options like `credentials` or `headers`
+    }),
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            GetAllStrains: concatPagination(),
+          },
+        },
+      },
+    }),
+  });
+}
+
+export function initializeApollo(initialState = null) {
+  const _apolloClient = apolloClient ?? createApolloClient();
+
+  // If your page has Next.js data fetching methods that use Apollo Client, the initial state
+  // gets hydrated here
+  if (initialState) {
+    // Get existing cache, loaded during client side data fetching
+    const existingCache = _apolloClient.extract();
+
+    // Merge the initialState from getStaticProps/getServerSideProps in the existing cache
+    const data = merge(existingCache, initialState, {
+      // combine arrays using object equality (like in sets)
+      arrayMerge: (destinationArray, sourceArray) => [
+        ...sourceArray,
+        ...destinationArray.filter(d => sourceArray.every(s => !isEqual(d, s))),
+      ],
+    });
+
+    // Restore the cache with the merged data
+    _apolloClient.cache.restore(data);
+  }
+  // For SSG and SSR always create a new Apollo Client
+  if (typeof window === "undefined") return _apolloClient;
+  // Create the Apollo Client once in the client
+  if (!apolloClient) apolloClient = _apolloClient;
+
+  return _apolloClient;
+}
+
+export function addApolloState(client, pageProps) {
+  if (pageProps?.props) {
+    pageProps.props[APOLLO_STATE_PROP_NAME] = client.cache.extract();
+  }
+
+  return pageProps;
+}
+
+export function useApollo(pageProps) {
+  const state = pageProps[APOLLO_STATE_PROP_NAME];
+  const store = useMemo(() => initializeApollo(state), [state]);
+  return store;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "msw": "^0.36.8",
         "postcss": "^8.4.6",
         "prettier": "^2.5.1",
+        "prettier-plugin-tailwindcss": "^0.1.7",
         "pretty-quick": "^3.1.3",
         "tailwindcss": "^3.0.19"
       }
@@ -7873,6 +7874,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.7.tgz",
+      "integrity": "sha512-tmBr45hCLuit2Cz9Pwow0/Jl1bGivYGsfcF29O+3sKcE++ybjz9dfie565S3ZsvAeV8uYer9SRMBWDsHPly2Lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -15473,6 +15486,13 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.7.tgz",
+      "integrity": "sha512-tmBr45hCLuit2Cz9Pwow0/Jl1bGivYGsfcF29O+3sKcE++ybjz9dfie565S3ZsvAeV8uYer9SRMBWDsHPly2Lg==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "msw": "^0.36.8",
     "postcss": "^8.4.6",
     "prettier": "^2.5.1",
+    "prettier-plugin-tailwindcss": "^0.1.7",
     "pretty-quick": "^3.1.3",
     "tailwindcss": "^3.0.19"
   },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,19 @@
 import "../styles/globals.css";
+import { useApollo } from "../lib/apolloClient";
+import { ApolloProvider, useApolloClient } from "@apollo/client";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   require("../mocks");
 }
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  const apolloClient = useApollo(pageProps);
+
+  return (
+    <ApolloProvider client={apolloClient}>
+      <Component {...pageProps} />
+    </ApolloProvider>
+  );
 }
 
 export default MyApp;

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,7 +12,7 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className={`flex justify-center items-center h-screen`}>
+      <main className={`flex h-screen items-center justify-center`}>
         <h1 className={`text-4xl`}>
           This is a{" "}
           <a

--- a/pages/strains/index.js
+++ b/pages/strains/index.js
@@ -1,26 +1,25 @@
-import { useState } from "react";
+import List, {
+  ALL_STRAINS_QUERY,
+  allStrainsQueryVars,
+} from "../../components/List";
+import { initializeApollo, addApolloState } from "../../lib/apolloClient";
 
-export default function Strains() {
-  const [strains, setStrains] = useState(null);
+const StrainsIndex = () => (
+  <>
+    <List />
+  </>
+);
 
-  const handleGetStrains = () => {
-    fetch("/api/strains")
-      .then(res => res.json())
-      .then(setStrains);
-  };
+export async function getServerSideProps() {
+  const apolloClient = initializeApollo();
 
-  return (
-    <>
-      <button onClick={handleGetStrains}>Load Strains</button>
-      {strains && (
-        <ul>
-          {strains.map(strain => (
-            <li key={strain.id}>
-              <h3>{strain.name}</h3>
-            </li>
-          ))}
-        </ul>
-      )}
-    </>
-  );
+  await apolloClient.query({
+    query: ALL_STRAINS_QUERY,
+    variables: allStrainsQueryVars,
+  });
+
+  return addApolloState(apolloClient, {
+    props: {},
+  });
 }
+export default StrainsIndex;


### PR DESCRIPTION
Add `ListItem` and `List` components to render a list of fetched strains.

"Show more" button currently not working because of CORS, but should work once its deployed to vercel.

Example Query
```
query Strains($skip: Int!, $take: Int!) {
  strains(skip: $skip, take: $take) {
    id
    name
  }
}
```