### PR TITLE
[chore] fix package-lock.json and code-syntax in apolloClient.js

### DIFF
--- a/lib/apolloClient.js
+++ b/lib/apolloClient.js
@@ -19,7 +19,7 @@ function createApolloClient() {
       typePolicies: {
         Query: {
           fields: {
-            strains: concatPagination(),
+            strains: concatPagination(), // Cache fetched data and paginate it (for fetchMore function)
           },
         },
       },
@@ -66,6 +66,5 @@ export function addApolloState(client, pageProps) {
 
 export function useApollo(pageProps) {
   const state = pageProps[APOLLO_STATE_PROP_NAME];
-  const store = useMemo(() => initializeApollo(state), [state]);
-  return store;
+  return useMemo(() => initializeApollo(state), [state]);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "lodash": "^4.17.21",
         "micro": "^9.3.4",
         "next": "12.0.10",
+        "nextjs-cors": "^2.1.0",
         "qs": "^6.10.3",
         "react": "17.0.2",
         "react-dom": "17.0.2"
@@ -3330,6 +3331,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -7187,6 +7200,17 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
+    "node_modules/nextjs-cors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nextjs-cors/-/nextjs-cors-2.1.0.tgz",
+      "integrity": "sha512-FC1LJMebe6E9fQ3hapW/4Q6zpz1Xpq8O8A2mYWma3S5EY8BP/t+IiTFsHm8Js5lRNyJ3DzQG/3VQu9pTA2LS/Q==",
+      "dependencies": {
+        "cors": "^2.8.5"
+      },
+      "peerDependencies": {
+        "next": "^8.1.1-canary.54 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -9278,6 +9302,14 @@
       "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/verror": {
@@ -12094,6 +12126,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -14999,6 +15040,14 @@
         }
       }
     },
+    "nextjs-cors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nextjs-cors/-/nextjs-cors-2.1.0.tgz",
+      "integrity": "sha512-FC1LJMebe6E9fQ3hapW/4Q6zpz1Xpq8O8A2mYWma3S5EY8BP/t+IiTFsHm8Js5lRNyJ3DzQG/3VQu9pTA2LS/Q==",
+      "requires": {
+        "cors": "^2.8.5"
+      }
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -16525,6 +16574,11 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
       "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",


### PR DESCRIPTION
- outdated version of package-lock.json replaced
- small code syntax refactor in **/lib/apolloClient.js** `useApollo's return` statement