### PR TITLE
[chore] update current api data fetching

### DIFF
--- a/components/List.js
+++ b/components/List.js
@@ -3,12 +3,15 @@ import ListItem from "./ListItem";
 
 export const ALL_STRAINS_QUERY = gql`
   query GetAllStrains($skip: Int!, $take: Int!) {
-    strains(skip: $skip, take: $take) {
-      id
+    allStrains(skip: $skip, take: $take) {
+      leaflyId
       name
       terpTop
       thc
-      cbd
+      terps: terps {
+        name
+        score
+      }
       flowerSvg
     }
   }
@@ -45,14 +48,14 @@ export default function List() {
     <div
       className={`flex h-auto w-screen flex-col divide-y dark:divide-slate-600`}
     >
-      {strains.map(listItem => (
+      {strains.map(strain => (
         <ListItem
-          key={listItem.id}
-          strainName={listItem.name}
-          topTerp={listItem.terpTop}
-          thcLevel={listItem.thc}
-          cbdLevel={listItem.cbd}
-          flowerSvg={listItem.flowerSvg}
+          key={strain.leaflyId}
+          strainName={strain.name}
+          topTerp={strain.terpTop}
+          thcLevel={strain.thc}
+          terps={strain.terps}
+          flowerSvg={strain.flowerSvg}
         />
       ))}
       <button

--- a/components/ListItem.js
+++ b/components/ListItem.js
@@ -34,10 +34,6 @@ export default function ListItem(props) {
           <li className={`capitalize`}>
             {props.topTerp && `${props.topTerp}`}
           </li>
-          <li>
-            <span className={`text-sm text-gray-500`}>CBD:</span>{" "}
-            {props.cbdLevel === 0 ? "-" : `${props.cbdLevel}%`}
-          </li>
         </ul>
       </div>
     </div>

--- a/lib/apolloClient.js
+++ b/lib/apolloClient.js
@@ -19,7 +19,7 @@ function createApolloClient() {
       typePolicies: {
         Query: {
           fields: {
-            strains: concatPagination(), // Cache fetched data and paginate it (for fetchMore function)
+            allStrains: concatPagination(), // Cache fetched data and paginate it (for fetchMore function)
           },
         },
       },

--- a/src/datasources/leafly.js
+++ b/src/datasources/leafly.js
@@ -1,4 +1,22 @@
 const { RESTDataSource } = require("apollo-datasource-rest");
+import map from "lodash/map";
+
+// only fetch strains with required data
+const withDataFilterQuery = `
+filter[thc][0][lte]=0.0
+&filter[thc][1][gte]=1.0
+&filter[thc][1][lte]=10.0
+&filter[thc][2][gte]=10.0
+&filter[thc][2][lte]=20.0
+&filter[thc][3][gte]=20.0
+&filter[strain_top_terp][]=caryophyllene
+&filter[strain_top_terp][]=humulene
+&filter[strain_top_terp][]=limonene
+&filter[strain_top_terp][]=linalool
+&filter[strain_top_terp][]=myrcene
+&filter[strain_top_terp][]=ocimene
+&filter[strain_top_terp][]=pinene
+`;
 
 class LeaflyAPI extends RESTDataSource {
   constructor() {
@@ -6,22 +24,26 @@ class LeaflyAPI extends RESTDataSource {
     this.baseURL = "https://consumer-api.leafly.com/api/";
   }
 
+  // map fetched data into our defined schema
   strainReducer(strain) {
     return {
-      id: strain.id || 0,
+      leaflyId: strain.id || 0,
       name: strain.name,
       flowerSvg: strain.flowerImageSvg,
       terpTop: strain.strainTopTerp || "no data",
       thc: strain.thc || 0,
-      cbd: strain.cbd || 0,
+      terps: map(strain.terps) || [],
     };
   }
 
   async getAllStrains(skip = 0, take = 10) {
-    const { hits } = await this.get("strain_playlists/v2", {
-      skip: skip,
-      take: take,
-    });
+    const { hits } = await this.get(
+      `strain_playlists/v2?${withDataFilterQuery}`,
+      {
+        skip: skip,
+        take: take,
+      }
+    );
     const res = hits.strain;
     return Array.isArray(res)
       ? res.map(strain => this.strainReducer(strain))

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,6 +1,6 @@
 module.exports = {
   Query: {
-    strains: async (_, { skip, take }, { dataSources }) => {
+    allStrains: async (_, { skip, take }, { dataSources }) => {
       return dataSources.leaflyAPI.getAllStrains(skip, take);
     },
   },

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -2,25 +2,20 @@ import { gql } from "apollo-server-micro";
 
 const typeDefs = gql`
   type Strain {
-    id: ID!
+    leaflyId: ID!
     name: String!
-    terpTop: String
+    terpTop: String!
     thc: Int
     cbd: Int
     flowerSvg: String
-    terpenes: [Terpene]
-    cannabinoids: [Cannabinoid]
+    terps: [Terpene]
   }
   type Terpene {
     name: String
     score: Float
   }
-  type Cannabinoid {
-    name: String
-    order: Int
-  }
   type Query {
-    strains(skip: Int!, take: Int!): [Strain]!
+    allStrains(skip: Int!, take: Int!): [Strain]!
   }
 `;
 module.exports = typeDefs;


### PR DESCRIPTION
- now only fetching strains with available data from external api
- terpenes objects name and score get mapped into an array

deployment fails because I defined a new graphQL schema and the dev. deployments server doesn't know how to handle the new request format. it will work after mergin with main branch.