### PR TITLE
[feature] terp chart visualisation and page styling

### DIFF
--- a/components/List.js
+++ b/components/List.js
@@ -2,7 +2,7 @@ import { gql, useQuery, NetworkStatus } from "@apollo/client";
 import Image from "next/image";
 import Modal from "./modal";
 import { useState } from "react";
-import { floor, orderBy } from "lodash";
+import { orderBy } from "lodash";
 import { isArray } from "lodash/lang";
 import TerpScoreChart from "./PolarChart";
 
@@ -125,16 +125,8 @@ export default function List() {
             <p className={`italic text-gray-700`}>
               These terpenes are found in {modalContent[1]}
             </p>
-            <ul>
-              {modalContent &&
-                modalContent[0].map(item => (
-                  <li key={item.name} className={`py-2`}>
-                    {item.name} - {floor(item.score, 3)}
-                  </li>
-                ))}
-            </ul>
+            {modalContent && <TerpScoreChart {...modalContent[0]} />}
           </div>
-          <TerpScoreChart {...modalContent[0]} />
         </Modal>
       )}
       <button

--- a/components/List.js
+++ b/components/List.js
@@ -120,10 +120,12 @@ export default function List() {
       ))}
       {isVisible && (
         <Modal handleClose={() => hideModal()}>
-          <h2 className={`text-center text-4xl`}>Terpene List</h2>
+          <h2 className={`text-center text-3xl font-bold tracking-wider`}>
+            Terpene List
+          </h2>
           <div className={`py-4 px-3`}>
             <p className={`italic text-gray-700`}>
-              These terpenes are found in {modalContent[1]}
+              These terpenes are found in {modalContent[1]}:
             </p>
             {modalContent && <TerpScoreChart {...modalContent[0]} />}
           </div>

--- a/components/List.js
+++ b/components/List.js
@@ -4,6 +4,7 @@ import Modal from "./modal";
 import { useState } from "react";
 import { floor, orderBy } from "lodash";
 import { isArray } from "lodash/lang";
+import TerpScoreChart from "./PolarChart";
 
 export const ALL_STRAINS_QUERY = gql`
   query GetAllStrains($skip: Int!, $take: Int!) {
@@ -133,6 +134,7 @@ export default function List() {
                 ))}
             </ul>
           </div>
+          <TerpScoreChart {...modalContent[0]} />
         </Modal>
       )}
       <button

--- a/components/NavMenu.js
+++ b/components/NavMenu.js
@@ -1,0 +1,48 @@
+import Link from "next/link";
+
+export default function NavMenu() {
+  const navArr = [
+    {
+      id: 1,
+      url: "strains",
+      label: "Strains",
+    },
+    {
+      id: 2,
+      url: "terps",
+      label: "Terpenes",
+    },
+    {
+      id: 3,
+      url: "profile",
+      label: "Profile",
+    },
+  ];
+  return (
+    <>
+      <nav
+        className={`z-20 h-48 w-full bg-slate-100 dark:bg-slate-800 md:h-20`}
+      >
+        <ul
+          role={`navigation`}
+          className={`flex h-full w-full flex-col items-center justify-evenly divide-y dark:divide-slate-600 md:flex-row md:divide-y-0 md:divide-x`}
+        >
+          {{ ...navArr } &&
+            navArr.map(item => (
+              <Link key={item.id} href={`/${item.url}`} passHref>
+                <a
+                  className={`group flex h-full w-full items-center justify-center text-xl font-medium tracking-wider text-slate-700 transition-all hover:bg-slate-300 dark:hover:bg-slate-700`}
+                >
+                  <li
+                    className={`flex w-20 items-center border-l-2 border-slate-200 pl-2.5 group-hover:border-slate-500 dark:border-slate-700 dark:text-slate-300 dark:group-hover:text-slate-100`}
+                  >
+                    {item.label}
+                  </li>
+                </a>
+              </Link>
+            ))}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/components/PolarChart.js
+++ b/components/PolarChart.js
@@ -11,21 +11,31 @@ import { PolarArea } from "react-chartjs-2";
 ChartJS.register(RadialLinearScale, ArcElement, Tooltip, Legend);
 
 const TerpScoreChart = props => {
-  const formatData = data => {
-    return _.map(Object.values(data), "score");
+  const formatData = (data, filter) => {
+    return _.map(Object.values(data), filter);
   };
 
   const data = {
     datasets: [
       {
         label: "Terpene Scores",
-        data: formatData(props),
+        data: formatData(props, "score"),
+        backgroundColor: [
+          "#5EB1BF",
+          "#54F2F2",
+          "#64403E",
+          "#F4E04D",
+          "#D2AB99",
+          "#7F7EFF",
+          "#00FFC5",
+        ],
       },
     ],
+    labels: formatData(props, "name"),
   };
 
   return (
-    <div className={`chart-container h-full w-full p-2`}>
+    <div className={`chart-container h-96 w-full p-2`}>
       <PolarArea data={data} options={Config} type={PolarArea} />
     </div>
   );

--- a/components/PolarChart.js
+++ b/components/PolarChart.js
@@ -1,0 +1,33 @@
+import { Config } from "./PolarChartConfig";
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { PolarArea } from "react-chartjs-2";
+
+ChartJS.register(RadialLinearScale, ArcElement, Tooltip, Legend);
+
+const TerpScoreChart = props => {
+  const formatData = data => {
+    return _.map(Object.values(data), "score");
+  };
+
+  const data = {
+    datasets: [
+      {
+        label: "Terpene Scores",
+        data: formatData(props),
+      },
+    ],
+  };
+
+  return (
+    <div className={`chart-container h-full w-full p-2`}>
+      <PolarArea data={data} options={Config} type={PolarArea} />
+    </div>
+  );
+};
+export default TerpScoreChart;

--- a/components/PolarChartConfig.js
+++ b/components/PolarChartConfig.js
@@ -1,0 +1,17 @@
+export const Config = {
+  //   animate in
+  animation: {
+    duration: 1,
+  },
+  scales: {
+    r: {
+      max: 0.5,
+      min: 0,
+      ticks: {
+        stepSize: 0.1,
+      },
+    },
+  },
+  maintainAspectRatio: false,
+  responsive: true,
+};

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,11 +36,11 @@ export default function Home() {
           <p className={`max-w-md text-right`}>
             You can get an overview of{" "}
             <Link href={`/strains`}>
-              <a className={`text-slate-100`}>strains</a>
+              <a className={`text-orange-700 dark:text-slate-100`}>strains</a>
             </Link>{" "}
             or read more about the different{" "}
             <Link href={`/terps`}>
-              <a className={`text-slate-100`}>terpenes</a>
+              <a className={`text-orange-700 dark:text-slate-100`}>terpenes</a>
             </Link>{" "}
             included in cannabis.
           </p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import Head from "next/head";
-import LogoIcon from "../components/LogoIcon";
+import Link from "next/link";
+import NavMenu from "../components/NavMenu";
 
 export default function Home() {
   return (
@@ -12,17 +13,38 @@ export default function Home() {
         />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div className={`flex flex-col items-center justify-center gap-6 pt-8`}>
-        <LogoIcon size={"lg"} />
-        <h2 className={`text-center text-4xl text-gray-800 dark:text-gray-200`}>
-          Under development.{" "}
-        </h2>
-        <a
-          className={`text-blue-500 hover:underline`}
-          href="https://github.com/br3zn/nf-capstone"
+      <NavMenu />
+      <div
+        className={`flex h-full flex-col items-center justify-evenly gap-6 pt-8 dark:text-slate-400`}
+      >
+        <h2
+          className={`text-center text-4xl font-black uppercase tracking-wide text-gray-800 dark:text-gray-300`}
         >
-          GitHub repository
-        </a>
+          What is{" "}
+          <span
+            className={`relative inline-block before:absolute before:-inset-1 before:block before:-skew-y-2 before:bg-red-500 `}
+          >
+            <span className={`relative`}>Bubatz?</span>
+          </span>
+        </h2>
+        <div className={`space-y-8 px-4 text-lg`}>
+          <p className={`max-w-md`}>
+            This app is about cannabis and the benefits of the different
+            terpenes included. The naming comes from the german slang word for a
+            joint.
+          </p>
+          <p className={`max-w-md text-right`}>
+            You can get an overview of{" "}
+            <Link href={`/strains`}>
+              <a className={`text-slate-100`}>strains</a>
+            </Link>{" "}
+            or read more about the different{" "}
+            <Link href={`/terps`}>
+              <a className={`text-slate-100`}>terpenes</a>
+            </Link>{" "}
+            included in cannabis.
+          </p>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
add terp score visualisation in a polar graph. displayed in the modal when clicking on a strain in the strain overview.

styled the landing page and added a nav component. "Light" mode also available 👽 

NOTE: "Terps" and "Profile" links currently go 404. 